### PR TITLE
Add divider option to AskCard

### DIFF
--- a/summarizer_service/application.py
+++ b/summarizer_service/application.py
@@ -269,6 +269,7 @@ class AskCard(BaseCard):
     def __init__(self):
         super().__init__(template='cards/ask/index.page', params=['question', 'context'])
         self.question = ''
+        self.divider = ''
         self.context = ''
         self.answer = ''
 
@@ -277,17 +278,21 @@ class AskCard(BaseCard):
         context_value = self.context or session.get('summary', '')
         return super().form() + [
             { 'name':'question','id':'question-textarea', 'label':'Question:', 'type':'text', 'value': self.question , 'tag': 'textarea'},
+            { 'name':'divider','id':'divider-select', 'label':'Divider:', 'type':'select', 'value': self.divider , 'tag': 'select', 'options': [ '', '---', '# Context', '# Previous Results' ] },
             { 'name':'context', 'id':'context-textarea', 'label':'Context:', 'type':'text', 'value': context_value, 'tag':'textarea' }
         ]
 
     def process(self):
         try:
             super().process()
-            self.answer = subprocess.check_output([ASK_BIN, 'any', self.question], input=self.context.encode('utf-8')).decode('utf-8')
+            my_input = (self.divider + '\n' + self.context)
+            logger.info(f"self.divider={self.divider} {my_input=}")
+            self.answer = subprocess.check_output([ASK_BIN, 'any', self.question], input=my_input.encode('utf-8')).decode('utf-8')
             app.config['MODEL_TRACKER'].note_usage(self.get_model_name())
             return self.get_template()
         except Exception as e:
             logger.error(f"Error during question answering: {e}")
+            import pdb;pdb.set_trace()
             return self.get_template()
 
 class ViaAPIModelCard(BaseCard):

--- a/summarizer_service/templates/cards/ask/index.page
+++ b/summarizer_service/templates/cards/ask/index.page
@@ -17,6 +17,11 @@
 {%if card.answer %}
 <div id="markdownText" class="form-control display"></div>
 
+<select id="divider" class="form-control hide">
+<option value=""></option>
+<option value="---">---</option>
+</select>
+
 <div id="plainText" class="form-control hide">{% for para in card.answer.split('\n') %}
 {{para}}<br />
 {% endfor %}

--- a/summarizer_service/templates/cards/ask/index.page
+++ b/summarizer_service/templates/cards/ask/index.page
@@ -17,11 +17,6 @@
 {%if card.answer %}
 <div id="markdownText" class="form-control display"></div>
 
-<select id="divider" class="form-control hide">
-<option value=""></option>
-<option value="---">---</option>
-</select>
-
 <div id="plainText" class="form-control hide">{% for para in card.answer.split('\n') %}
 {{para}}<br />
 {% endfor %}

--- a/summarizer_service/templates/cards/main-form.body
+++ b/summarizer_service/templates/cards/main-form.body
@@ -1,14 +1,41 @@
 <form id="mainform" method="POST">
   <div id="grid">
     {% for field in card.form() %}
-    {% set tag = field.get('tag', 'input')  %}
-    {% set v = field.get('value', '')  %}
-    <label for="{{ field['name']|escape }}-{{ tag|escape }}">{{ field['label']|escape }}</label>
-    {% if tag == 'input' %}<{{tag}} {% for key, value in field.items() %}{% if key != 'tag' %}{{key|escape}}="{{value|escape}}"{% endif %} {% endfor %}></{{tag}}>
-    {% elif tag == 'textarea' %}<div id="{{field['name']|escape}}-{{tag}}-div" class="clear-div"><{{tag}} {% for key, value in field.items() %}{% if key not in ['tag', 'value'] %}{{key|escape}}="{{value|escape}}" {% endif %}{% endfor %}>{{v}}</{{tag}}><button class="clear-button" type="button" onclick="toggleTextareaContent(this)">[X]</button></div>{% endif %}
+      {% set tag = field.get('tag', 'input') %}
+      {% set value = field.get('value', '') %}
 
-{% endfor %}
+      <label for="{{ field['name']|escape }}-{{ tag|escape }}">{{ field['label']|escape }}</label>
+
+      {% if tag == 'input' %}
+        <input 
+          {% for key, val in field.items() if key != 'tag' %}
+            {{ key|escape }}="{{ val|escape }}"
+          {% endfor %}
+        >
+      {% elif tag == 'textarea' %}
+        <div id="{{field['name']|escape}}-{{tag}}-div" class="clear-div">
+          <textarea 
+            {% for key, val in field.items() if key not in ['tag', 'value'] %}
+              {{ key|escape }}="{{ val|escape }}"
+            {% endfor %}
+          >{{ value }}</textarea>
+          <button class="clear-button" type="button" onclick="toggleTextareaContent(this)">[X]</button>
+        </div>
+      {% elif tag == 'select' %}
+        <select name="{{ field['name']|escape }}"
+          {% for key, val in field.items() if key not in ['tag', 'options', 'value'] %}
+            {{ key|escape }}="{{ val|escape }}"
+          {% endfor %}
+        >
+          {% for option in field.get('options', []) %}
+            <option value="{{ option|escape }}" {% if option == value %}selected{% endif %}>{{ option|escape }}</option>
+          {% endfor %}
+        </select>
+      {% else %}
+        <!-- Handle other tags or provide a default -->
+        <p>Unsupported field type: {{ tag|escape }}</p> 
+      {% endif %}
+    {% endfor %}
   </div>
   <div id="loading"></div>
 </form>
-


### PR DESCRIPTION
This pull request introduces a divider option to the AskCard, allowing users to specify a divider string to prepend to the context before passing it to the question answering service.

**Changes:**
*   Added a `divider` attribute to the `AskCard` class.
*   Updated the `form()` method to include a `select` input for the divider with options for no divider, a simple divider ('---'), '# Context', and '# Previous Results'.
*   Modified the `process()` method to prepend the selected divider to the `context` string before passing it to the `ASK_BIN` subprocess.
*   Added logging to show the divider and pre-processed inputs to the question answering service.
*   Added `pdb.set_trace()` inside the `except` block of the `process()` method to help with debugging.
*   Updated `main-form.body` to render the new select field.

